### PR TITLE
Fix SIGSEGV when compiled without KAWPOW

### DIFF
--- a/src/base/net/stratum/Pool.h
+++ b/src/base/net/stratum/Pool.h
@@ -46,7 +46,9 @@ public:
         MODE_POOL,
         MODE_DAEMON,
         MODE_SELF_SELECT,
+#       ifdef XMRIG_ALGO_KAWPOW
         MODE_AUTO_ETH,
+#       endif
 #       ifdef XMRIG_FEATURE_BENCHMARK
         MODE_BENCHMARK,
 #       endif
@@ -142,7 +144,11 @@ private:
     bool m_submitToOrigin           = false;
     Coin m_coin;
     int m_keepAlive                 = 0;
+#   ifdef XMRIG_ALGO_KAWPOW
     Mode m_mode                     = MODE_AUTO_ETH;
+#   else
+    Mode m_mode                     = MODE_POOL;
+#   endif
     ProxyUrl m_proxy;
     std::bitset<FLAG_MAX> m_flags   = 0;
     String m_fingerprint;


### PR DESCRIPTION
Compile fails due to missing `MODE_AUTO_ETH` state when KawPow is disabled with `-DWITH_KAWPOW=OFF`

Which one would normally do in a CPU-only setup because there is no KawPow miner then and it doesn't make sense to compile any of it.

Tested on GPU rigs and algo switching works properly when KAWPOW is ON
Tested on CPU rigs and same result.
Both tested for months.