### PR TITLE
Check and save any autosized algos before launching the moBenchmark

### DIFF
--- a/src/App.cpp
+++ b/src/App.cpp
@@ -90,6 +90,9 @@ int xmrig::App::exec()
     m_controller->config()->benchmark().set_controller(m_controller);
 
     if (m_controller->config()->benchmark().isNewBenchRun() || m_controller->config()->isRebenchAlgo()) {
+        if (m_controller->config()->isShouldSave()) {
+            m_controller->config()->save();
+        }
         m_controller->config()->benchmark().start();
     } else {
         m_controller->start();

--- a/src/core/MoBenchmark.cpp
+++ b/src/core/MoBenchmark.cpp
@@ -77,6 +77,7 @@ rapidjson::Value MoBenchmark::toJSON(rapidjson::Document &doc) const
     Value obj(kObjectType);
 
     for (const auto &a : m_controller->miner()->algorithms()) {
+        if (algo_perf[a.id()] == 0.0f) continue;
         obj.AddMember(StringRef(a.shortName()), algo_perf[a.id()], allocator);
     }
 


### PR DESCRIPTION
Sometimes, mostly with CUDA, the auto-configured first-run algorithm definitions are unworkable and crash before the entire run of benchmarks, and no config file gets written.

Trigger a config file save just before launching benchmark mode;

Filter saved algo-perf items to leave out any zeros -- this results in the pre-saved config having an empty set for algo-perf, which still triggers a rebench automatically next run after any needed algo-definition editing.  And then the normal config-change-and-save still occurs after benchmark at original Controller start to save the benchmark results as always.