### PR TITLE
Fix --threads generates "*" profile without "kawpow":false to negate it.

### DIFF
--- a/src/backend/cpu/CpuBackend.cpp
+++ b/src/backend/cpu/CpuBackend.cpp
@@ -266,7 +266,7 @@ bool xmrig::CpuBackend::isEnabled() const
 
 bool xmrig::CpuBackend::isEnabled(const Algorithm &algorithm) const
 {
-    return !d_ptr->controller->config()->cpu().threads().get(algorithm).isEmpty();
+    return algorithm.isValid() && !d_ptr->controller->config()->cpu().threads().get(algorithm).isEmpty();
 }
 
 

--- a/src/core/config/ConfigTransform.cpp
+++ b/src/core/config/ConfigTransform.cpp
@@ -44,6 +44,9 @@ static const char *kAsterisk    = "*";
 static const char *kEnabled     = "enabled";
 static const char *kIntensity   = "intensity";
 static const char *kThreads     = "threads";
+#ifdef XMRIG_ALGO_KAWPOW
+static const char *kKawPow      = "kawpow";
+#endif
 
 
 static inline uint64_t intensity(uint64_t av)
@@ -103,6 +106,9 @@ void xmrig::ConfigTransform::finalize(rapidjson::Document &doc)
         profile.AddMember(StringRef(kThreads),   m_threads, allocator);
         profile.AddMember(StringRef(kAffinity),  m_affinity, allocator);
 
+#       ifdef XMRIG_ALGO_KAWPOW
+        doc[CpuConfig::kField].AddMember(StringRef(kKawPow), false, doc.GetAllocator());
+#       endif
         doc[CpuConfig::kField].AddMember(StringRef(kAsterisk), profile, doc.GetAllocator());
     }
 


### PR DESCRIPTION
When using a mostly empty `config.json` and the `--threads` argument, ConfigTransform generates a `"*"` profile without `"kawpow":false` to ensure benchmark and etc do not try to use the unsupported algo (enabled by `"*"`...)

This adds the negation for kawpow when the asterisk profile is generated.