### PR TITLE
Fix for crash when sending config via API

### DIFF
--- a/src/core/MoBenchmark.cpp
+++ b/src/core/MoBenchmark.cpp
@@ -76,7 +76,7 @@ rapidjson::Value MoBenchmark::toJSON(rapidjson::Document &doc) const
 
     Value obj(kObjectType);
 
-    for (const auto &a : m_controller->miner()->algorithms()) {
+    for (const Algorithm a : Algorithm::all()) {
         if (algo_perf[a.id()] == 0.0f) continue;
         obj.AddMember(StringRef(a.name()), algo_perf[a.id()], allocator);
     }
@@ -86,7 +86,7 @@ rapidjson::Value MoBenchmark::toJSON(rapidjson::Document &doc) const
 
 void MoBenchmark::read(const rapidjson::Value &value)
 {
-    for (const Algorithm::Id algo : Algorithm::all([this](const Algorithm&) { return true; })) {
+    for (const Algorithm::Id algo : Algorithm::all()) {
         algo_perf[algo] = 0.0f;
     }
     if (value.IsObject()) {


### PR DESCRIPTION
Traced back and found accessing algorithms via controller->miner linkage was the cause.

Swapped to use the `Algorithm::all()` method instead (which does not need a no-op filter function, it no-ops when null anyway)

Fully tested by sending a config file to it, and observing no crash.