### PR TITLE
Fix upstream benchmark feature clash with MoBenchmark

### DIFF
--- a/src/App.cpp
+++ b/src/App.cpp
@@ -86,20 +86,21 @@ int xmrig::App::exec()
     }
 
 #   ifdef XMRIG_FEATURE_MO_BENCHMARK
-    m_controller->pre_start();
-    m_controller->config()->benchmark().set_controller(m_controller);
+    if (pool.mode() != Pool::MODE_BENCHMARK) {
+        m_controller->pre_start();
+        m_controller->config()->benchmark().set_controller(m_controller);
 
-    if (m_controller->config()->benchmark().isNewBenchRun() || m_controller->config()->isRebenchAlgo()) {
-        if (m_controller->config()->isShouldSave()) {
-            m_controller->config()->save();
+        if (m_controller->config()->benchmark().isNewBenchRun() || m_controller->config()->isRebenchAlgo()) {
+            if (m_controller->config()->isShouldSave()) {
+                m_controller->config()->save();
+            }
+            m_controller->config()->benchmark().start();
+        } else {
+            m_controller->start();
         }
-        m_controller->config()->benchmark().start();
-    } else {
-        m_controller->start();
-    }
-#   else
-    m_controller->start();
+    } else
 #   endif
+    m_controller->start();
 
     rc = uv_run(uv_default_loop(), UV_RUN_DEFAULT);
     uv_loop_close(uv_default_loop());


### PR DESCRIPTION
When the upstream benchmark feature (`--bench=1M`) is used with MoBenchmark also enabled, the algo-perf tests would preempt the launch of fake-pool made for the other benchmark mode.

Skip the MoBenchmark if the `pool.mode()` is `Pool::MODE_BENCHMARK` and continue launch normally.