### PR TITLE
MoBenchmark: use ifdefs to avoid bugs when algos are compiled out

### DIFF
--- a/src/core/MoBenchmark.cpp
+++ b/src/core/MoBenchmark.cpp
@@ -118,10 +118,16 @@ double MoBenchmark::get_algo_perf(Algorithm::Id algo) const {
         case Algorithm::CN_RWZ:          return algo_perf[Algorithm::CN_R] / 3 * 4;
         case Algorithm::CN_ZLS:          return algo_perf[Algorithm::CN_R] / 3 * 4;
         case Algorithm::CN_DOUBLE:       return algo_perf[Algorithm::CN_R] / 2;
+#       ifdef XMRIG_ALGO_CN_LITE
         case Algorithm::CN_LITE_0:       return algo_perf[Algorithm::CN_LITE_1];
+#       endif
+#       ifdef XMRIG_ALGO_CN_PICO
         case Algorithm::CN_PICO_TLO:     return algo_perf[Algorithm::CN_PICO_0];
+#       endif
+#       ifdef XMRIG_ALGO_RANDOMX
         case Algorithm::RX_SFX:          return algo_perf[Algorithm::RX_0];
         case Algorithm::RX_XEQ:          return algo_perf[Algorithm::RX_ARQ];
+#       endif
         default:                         return algo_perf[algo];
     }
 }
@@ -147,17 +153,21 @@ void MoBenchmark::start() {
     m_bench_job = Job(false, Algorithm(bench_algos[m_bench_algo]), "benchmark");
     m_bench_job.setId(algo.name()); // need to set different id so that workers will see job change
     switch (algo.id()) {
+#     ifdef XMRIG_ALGO_KAWPOW
       case Algorithm::KAWPOW_RVN:
           m_bench_job.setBlob("4c38e8a5f7b2944d1e4274635d828519b97bc64a1f1c7896ecdbb139989aa0e80000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
           m_bench_job.setDiff(Job::toDiff(strtoull("000000639c000000", nullptr, 16)));
           m_bench_job.setHeight(1500000);
           break;
+#     endif
 
+#     ifdef XMRIG_ALGO_GHOSTRIDER
       case Algorithm::GHOSTRIDER_RTM:
       case Algorithm::FLEX_KCN:
           m_bench_job.setBlob("000000208c246d0b90c3b389c4086e8b672ee040d64db5b9648527133e217fbfa48da64c0f3c0a0b0e8350800568b40fbb323ac3ccdf2965de51b9aaeb939b4f11ff81c49b74a16156ff251c00000000");
           m_bench_job.setDiff(1000);
           break;
+#     endif
 
       default:
           // 99 here to trigger all future bench_algo versions for auto veriant detection based on block version
@@ -215,11 +225,15 @@ void MoBenchmark::onJobResult(const JobResult& result) {
             if (!(hashrate = t[1]))
                 if (!(hashrate = t[0]))
                     hashrate = static_cast<double>(m_hash_count) * result.diff / (now - m_bench_start) * 1000.0f;
+#       ifdef XMRIG_ALGO_KAWPOW
         if (algo.id() == Algorithm::KAWPOW_RVN) hashrate /= ((double)0xFFFFFFFFFFFFFFFF) / 0xFF000000;
+#       endif
         algo_perf[algo.id()] = hashrate; // store hashrate result
         LOG_INFO("%s " BRIGHT_BLACK_BG(WHITE_BOLD_S " Algo " MAGENTA_BOLD_S "%s" WHITE_BOLD_S " hashrate: " CYAN_BOLD_S "%f "), Tags::benchmark(), algo.name(), hashrate);
         run_next_bench_algo();
-    } else switch (algo.id()) { // Update GhostRider algo job to produce more accurate perf results
+    }
+#   ifdef XMRIG_ALGO_GHOSTRIDER
+    else switch (algo.id()) { // Update GhostRider algo job to produce more accurate perf results
         case Algorithm::GHOSTRIDER_RTM: {
             uint8_t* blob = m_bench_job.blob();
             ++ *reinterpret_cast<uint32_t*>(blob+4);
@@ -228,6 +242,7 @@ void MoBenchmark::onJobResult(const JobResult& result) {
         }
         default:;
     }
+#   endif
 }
 
 uint64_t MoBenchmark::get_now() const { // get current time in ms

--- a/src/core/MoBenchmark.h
+++ b/src/core/MoBenchmark.h
@@ -35,20 +35,36 @@ class Job;
 class MoBenchmark : public IJobResultListener {
 
         const Algorithm::Id bench_algos[15] = {
+#           ifdef XMRIG_ALGO_GHOSTRIDER
             Algorithm::FLEX_KCN,
             Algorithm::GHOSTRIDER_RTM,
+#           endif
             Algorithm::CN_R,
+#           ifdef XMRIG_ALGO_CN_LITE
             Algorithm::CN_LITE_1,
+#           endif
+#           ifdef XMRIG_ALGO_CN_HEAVY
             Algorithm::CN_HEAVY_XHV,
+#           endif
+#           ifdef XMRIG_ALGO_CN_PICO
             Algorithm::CN_PICO_0,
+#           endif
             Algorithm::CN_CCX,
+#           ifdef XMRIG_ALGO_CN_GPU
             Algorithm::CN_GPU,
+#           endif
+#           ifdef XMRIG_ALGO_ARGON2
             Algorithm::AR2_CHUKWA_V2,
+#           endif
+#           ifdef XMRIG_ALGO_KAWPOW
             Algorithm::KAWPOW_RVN,
+#           endif
+#           ifdef XMRIG_ALGO_RANDOMX
             Algorithm::RX_0,
             Algorithm::RX_GRAFT,
             Algorithm::RX_ARQ,
             Algorithm::RX_XLA,
+#           endif
             Algorithm::INVALID
         };
 


### PR DESCRIPTION
Previously if compiled `WITH_KAWPOW=OFF` (or others), as would be very common for a CPU-only compilation, the benchmark would always attempt to run every time even if it was pointless, because the KawPow algo_perf would always be 0 since it can't be benchmarked, but was still included in the `bench_algos`.  It would also say it was skipping an algo named `invalid` since the name strings are not included (in `src/base/crypto/Algorithm.h`) for algos disabled by CMake options.  Removing the compile-disabled algos from the `bench_algos` is enough to fix the bug by itself, but then also wrap all other instances of possibly-compiled-without algos with appropriate `#ifdefs` since the code is unneeded/unreachable in those cases anyway.