### PR TITLE
MoBenchmark: restore listener at the end of finish()

### DIFF
--- a/src/core/MoBenchmark.cpp
+++ b/src/core/MoBenchmark.cpp
@@ -56,6 +56,7 @@ void MoBenchmark::finish() {
     LOG_INFO("%s " BRIGHT_BLACK_BG(CYAN_BOLD_S " ALGO PERFORMANCE CALIBRATION COMPLETE "), Tags::benchmark());
     m_controller->miner()->pause(); // do not compute anything before job from the pool
     JobResults::stop();
+    JobResults::setListener(m_controller->network(), m_controller->config()->cpu().isHwAES());
     m_controller->start();
 }
 


### PR DESCRIPTION
Fixes #131 

`setListener` line was removed between v6.21.3-mo4 and v6.21.3-mo5.  It appears that the logic [at line 187](https://github.com/MoneroOcean/xmrig/blob/master/src/core/MoBenchmark.cpp#L187) should have replaced this by restoring the correct listener when the first result comes back that isn't tagged "benchmark", but it doesn't work.

Restoring this line makes everything happy again.