### PR TITLE
MoBenchmark: don't write algo_perf==0.0 items to config

### DIFF
--- a/src/core/MoBenchmark.cpp
+++ b/src/core/MoBenchmark.cpp
@@ -67,6 +67,7 @@ rapidjson::Value MoBenchmark::toJSON(rapidjson::Document &doc) const
     Value obj(kObjectType);
 
     for (const Algorithm a : Algorithm::all()) {
+        if (algo_perf[a.id()] == 0.0f) continue;
         obj.AddMember(StringRef(a.name()), algo_perf[a.id()], allocator);
     }
 


### PR DESCRIPTION
Since `flush_perf()` was added, the config file gets spammed with useless `algo_perf` entries for algos that will always be zero.  Avoid writing them with a simple filter line added in `toJSON()`.  They will be re-filled by `flush_perf()` anyway if a benchmark is run, but most of them are deadcoins anyway and will never get benchmarked.

This intentionally does not filter out `-1` which is now used as a way to disable algos from ever being selected or benchmarked.