### PR TITLE
flex: fix compilation error with MSVC 2022

### DIFF
--- a/src/crypto/flex/flex.cpp
+++ b/src/crypto/flex/flex.cpp
@@ -78,7 +78,7 @@ static void getAlgoString(void *mem, unsigned int size, uint8_t* selectedAlgoOut
   unsigned char *p = (unsigned char *)mem;
   unsigned int len = size/2;
   unsigned char j = 0;
-  bool selectedAlgo[algoCount];
+  bool* selectedAlgo = new bool[algoCount];
   for(int z=0; z < algoCount; z++) {
 	  selectedAlgo[z] = false;
   }
@@ -97,6 +97,7 @@ static void getAlgoString(void *mem, unsigned int size, uint8_t* selectedAlgoOut
 		}
 	}
   }
+  delete [] selectedAlgo;
 }
 
 void print_hex_memory(void *mem, unsigned int size) {


### PR DESCRIPTION
This appears to fix the MSVC 2022 compilation issue:
```
  C:\src\xmrig\src\crypto\flex\flex.cpp(79,21): error C2131: expression did not evaluate to a constant [C:\src\xmrig\build\cpu\xmrig.vcxproj]
  C:\src\xmrig\src\crypto\flex\flex.cpp(81,20): error C3863: array type 'bool [algoCount]' is not assignable [C:\src\xmrig\build\cpu\xmrig.vcxproj]
```

Also appears to still work on Linux (gcc 12.3.0)