### PR TITLE
Fixup switch warning; Use count_limit2; Benchmark ghostrider before flex

### DIFF
--- a/src/backend/cpu/platform/BasicCpuInfo.cpp
+++ b/src/backend/cpu/platform/BasicCpuInfo.cpp
@@ -387,8 +387,10 @@ xmrig::CpuThreads xmrig::BasicCpuInfo::threads(const Algorithm &algorithm, uint3
 
 #   ifdef XMRIG_ALGO_GHOSTRIDER
     switch (algorithm.id()) {
-        case Algorithm::GHOSTRIDER_RTM: return CpuThreads(std::max<size_t>(count / 2, 1), 8);
-        case Algorithm::FLEX_KCN:       return CpuThreads(std::max<size_t>(count / 2, 1), 1);
+        case Algorithm::GHOSTRIDER_RTM: return CpuThreads(std::max<size_t>(count_limit2, 1), 8);
+        case Algorithm::FLEX_KCN:       return CpuThreads(std::max<size_t>(count_limit2, 1), 1);
+        default:
+            break;
     }
 #   endif
 

--- a/src/core/MoBenchmark.h
+++ b/src/core/MoBenchmark.h
@@ -55,8 +55,8 @@ class MoBenchmark : public IJobResultListener {
             // below here use prefetch-disabled MSR setup, keep them grouped
             // so MSR setting doesn't have to flip back and forth
 #           ifdef XMRIG_ALGO_GHOSTRIDER
-            Algorithm::FLEX_KCN,
             Algorithm::GHOSTRIDER_RTM,
+            Algorithm::FLEX_KCN,
 #           endif
 #           ifdef XMRIG_ALGO_CN_HEAVY
             Algorithm::CN_HEAVY_XHV,


### PR DESCRIPTION
Fix spam during compilation:
```
/usr/src/xmrig/src/backend/cpu/platform/BasicCpuInfo.cpp: In member function ‘virtual xmrig::CpuThreads xmrig::BasicCpuInfo::threads(const xmrig::Algorithm&, uint32_t) const’:
/usr/src/xmrig/src/backend/cpu/platform/BasicCpuInfo.cpp:393:12: warning: enumeration value ‘INVALID’ not handled in switch [-Wswitch]
  393 |     switch (algorithm.id()) {
      |            ^
/usr/src/xmrig/src/backend/cpu/platform/BasicCpuInfo.cpp:393:12: warning: enumeration value ‘CN_0’ not handled in switch [-Wswitch]
/usr/src/xmrig/src/backend/cpu/platform/BasicCpuInfo.cpp:393:12: warning: enumeration value ‘CN_1’ not handled in switch [-Wswitch]
/usr/src/xmrig/src/backend/cpu/platform/BasicCpuInfo.cpp:393:12: warning: enumeration value ‘CN_2’ not handled in switch [-Wswitch]
/usr/src/xmrig/src/backend/cpu/platform/BasicCpuInfo.cpp:393:12: warning: enumeration value ‘CN_R’ not handled in switch [-Wswitch]
/usr/src/xmrig/src/backend/cpu/platform/BasicCpuInfo.cpp:393:12: warning: enumeration value ‘CN_FAST’ not handled in switch [-Wswitch]
...
```

Also use `count_limit2` like everything else does, and do ghostrider before flex in benchmarking (in case the subalgo optimization test/selections matter).