### PR TITLE
Fix unused warning with C++17 [[maybe_unused]] decoration

### DIFF
--- a/src/crypto/cn/CryptoNight_x86.h
+++ b/src/crypto/cn/CryptoNight_x86.h
@@ -77,7 +77,7 @@ static inline void do_skein_hash(const uint8_t *input, size_t len, uint8_t *outp
 }
 
 static inline void do_flex_skein_hash(const uint8_t* input, size_t len, uint8_t* output) {
-    int r = skein_hash(512, input, 8 * len, (uint8_t*)output);
+    [[maybe_unused]] int r = skein_hash(512, input, 8 * len, (uint8_t*)output);
     assert(SKEIN_SUCCESS == r);
 }
 


### PR DESCRIPTION
Get rid of the warning:
```
In file included from /usr/src/xmrig/src/crypto/cn/CnHash.cpp:29:
/usr/src/xmrig/src/crypto/cn/CryptoNight_x86.h: In function ‘void do_flex_skein_hash(const uint8_t*, size_t, uint8_t*)’:
/usr/src/xmrig/src/crypto/cn/CryptoNight_x86.h:80:9: warning: unused variable ‘r’ [-Wunused-variable]
   80 |     int r = skein_hash(512, input, 8 * len, (uint8_t*)output);
      |         ^
```