### PR TITLE
Restore MacOS build for Intel CPUs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,35 @@ jobs:
           name: macos_build
           path: macos_build.tar.gz
 
+  build_macos_intel:
+    name: Build MacOS (Intel) artifacts
+    runs-on: macos-13
+    steps:
+      - name: Prepare MacOS tools
+        run: |
+          brew install cmake libuv openssl hwloc
+      - name: Checkout code
+        uses: actions/checkout@master
+      - name: Build hwloc on MacOS
+        run: |
+          curl -O https://download.open-mpi.org/release/hwloc/v2.1/hwloc-2.1.0.tar.bz2
+          tar xjf hwloc-2.1.0.tar.bz2
+          cd hwloc-2.1.0
+          ./configure --disable-shared --enable-static --disable-io --disable-libxml2
+          make -j$(sysctl -n hw.logicalcpu)
+          cd ..
+      - name: Build project on MacOS
+        run: |
+          cmake . -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DHWLOC_INCLUDE_DIR=hwloc-2.1.0/include -DHWLOC_LIBRARY=hwloc-2.1.0/hwloc/.libs/libhwloc.a
+          make -j$(sysctl -n hw.logicalcpu)
+          cp src/config.json .
+          tar cfz macos_build_intel.tar.gz xmrig config.json
+      - name: Upload MacOS build artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: macos_build_intel
+          path: macos_build_intel.tar.gz
+
   build_lin_rh7:
     name: Build CentOS 7 artifacts
     runs-on: ubuntu-latest
@@ -109,7 +138,7 @@ jobs:
           path: centos7_build.tar.gz
 
   deploy:
-    needs: [build_win, build_lin, build_macos, build_lin_rh7]
+    needs: [build_win, build_lin, build_macos, build_macos_intel, build_lin_rh7]
     name: Create release and upload artifacts
     runs-on: ubuntu-latest
     steps:
@@ -138,6 +167,10 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: macos_build
+      - name: Download MacOS (Intel) build artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: macos_build_intel
       - name: Download CentOS 7 build artifacts
         uses: actions/download-artifact@v1
         with:
@@ -168,6 +201,15 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: macos_build/macos_build.tar.gz
           asset_name: xmrig-${{steps.version.outputs.VERSION}}-mac64.tar.gz
+          asset_content_type: application/zip
+      - name: Upload MacOS (Intel) build release asset
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: macos_build_intel/macos_build_intel.tar.gz
+          asset_name: xmrig-${{steps.version.outputs.VERSION}}-mac-intel.tar.gz
           asset_content_type: application/zip
       - name: Upload CentOS 7 build release asset
         uses: actions/upload-release-asset@v1.0.1


### PR DESCRIPTION
Fixes #140 

Not sure if this is even wanted or not, but at least two users complained.

Other option is to just change `macos-latest` back to `macos-13` and then not build a release for ARM (not sure how many users would complain then, though).