### PR TITLE
Reconnect when algo-perf or algo-min-time have been changed

### DIFF
--- a/src/core/MoBenchmark.cpp
+++ b/src/core/MoBenchmark.cpp
@@ -79,6 +79,14 @@ void MoBenchmark::flush_perf() {
    for (const Algorithm::Id algo : Algorithm::all()) algo_perf[algo] = 0.0f;
 }
 
+bool MoBenchmark::compare_perf(Config *previousConfig) {
+   // returns equivalent of == comparison
+   for (const Algorithm::Id algo : Algorithm::all()) {
+       if (algo_perf[algo] != previousConfig->benchmark().algo_perf[algo]) return false;
+   }
+   return true;
+}
+
 void MoBenchmark::read(const rapidjson::Value &value)
 {
     flush_perf();

--- a/src/core/MoBenchmark.h
+++ b/src/core/MoBenchmark.h
@@ -31,6 +31,7 @@ namespace xmrig {
 class Controller;
 class Miner;
 class Job;
+class Config;
 
 class MoBenchmark : public IJobResultListener {
 
@@ -95,6 +96,7 @@ class MoBenchmark : public IJobResultListener {
         void set_controller(std::shared_ptr<Controller> controller) { m_controller = controller.get(); }
 
         void start_perf(); // start benchmarks
+        bool compare_perf(Config *previousConfig);
         void flush_perf();
 
         bool isNewBenchRun() const { return m_isNewBenchRun; }


### PR DESCRIPTION
When config is reloaded and has changed MO-specific config items that are in the login packet, reconnect.  Also add messages about why a reconnect is happening, as an improvement.

Previously, changing `algo-perf` or `algo-min-time` would not trigger a reconnection/re-login to update the actual state of things.

Tested:
![image](https://github.com/MoneroOcean/xmrig/assets/2391234/72731aa7-fe5e-4ccf-ab70-31cc793a3d44)