### PR TITLE
CpuBackend: do not return early if algo changed but threads are same

### DIFF
--- a/src/backend/cpu/CpuBackend.cpp
+++ b/src/backend/cpu/CpuBackend.cpp
@@ -352,7 +352,7 @@ void xmrig::CpuBackend::setJob(const Job &job)
     const auto &cpu = d_ptr->controller->config()->cpu();
 
     auto threads = cpu.get(d_ptr->controller->miner(), job.algorithm());
-    if (!d_ptr->threads.empty() && d_ptr->threads.size() == threads.size() && std::equal(d_ptr->threads.begin(), d_ptr->threads.end(), threads.begin())) {
+    if (!d_ptr->threads.empty() && d_ptr->threads.size() == threads.size() && std::equal(d_ptr->threads.begin(), d_ptr->threads.end(), threads.begin()) && d_ptr->algo == job.algorithm()) {
         return;
     }
 


### PR DESCRIPTION
fixes bug where backend did not stop and reinitialize on some systems between rx/0 and flex or such when thread profiles were the same