### PR TITLE
CpuWorker: remove extra CN-GPU test

### DIFF
--- a/src/backend/cpu/CpuWorker.cpp
+++ b/src/backend/cpu/CpuWorker.cpp
@@ -198,11 +198,6 @@ bool xmrig::CpuWorker<N>::selfTest()
 #                       endif
                         ;
 
-#       ifdef XMRIG_ALGO_CN_GPU
-        if (! (!rc || N > 1)) {
-            return verify(Algorithm::CN_GPU, test_output_gpu);
-        } else
-#       endif
         return rc;
     }
 


### PR DESCRIPTION
Don't need to run CN-GPU testing twice.