### PR TITLE
fix: wrong function name

### DIFF
--- a/src/crypto/flex/flex_keccak.c
+++ b/src/crypto/flex/flex_keccak.c
@@ -1775,7 +1775,7 @@ static void keccak_core(sph_keccak_context *kc, const void *data, size_t len,
     for (j = 0; j < 50; j += 2)                                                \
       UNINTERLEAVE(kc->u.narrow[j], kc->u.narrow[j + 1]);                      \
     for (j = 0; j < d; j += 4)                                                 \
-      flex_enc32le_aligned(u.tmp + j, kc->u.narrow[j >> 2]);                    \
+      sph_enc32le_aligned(u.tmp + j, kc->u.narrow[j >> 2]);                    \
     memcpy(dst, u.tmp, d);                                                     \
     keccak_init(kc, (unsigned)d << 3);                                         \
   }


### PR DESCRIPTION
Looking at the Kylacoin source code, this is incorrect.
https://github.com/kylacoin/kylacoin/blob/fe6f2ad64ffcc4eae213c378336cf574f68b8672/src/crypto/flex/sph/keccak.c#L1697

```
ninja: job failed: /usr/bin/cc -DHAVE_BUILTIN_CLEAR_CACHE -DHAVE_ROTR -DHAVE_SYSLOG_H -DNDEBUG -DUNICODE -DXMRIG_ALGO_ARGON2 -DXMRIG_ALGO_CN_FEMTO -DXMRIG_ALGO_CN_HEAVY -DXMRIG_ALGO_CN_LITE -DXMRIG_ALGO_CN_PICO -DXMRIG_ALGO_GHOSTRIDER -DXMRIG_ALGO_KAWPOW -DXMRIG_ALGO_RANDOMX -DXMRIG_FEATURE_API -DXMRIG_FEATURE_BENCHMARK -DXMRIG_FEATURE_DMI -DXMRIG_FEATURE_ENV -DXMRIG_FEATURE_HTTP -DXMRIG_FEATURE_HWLOC -DXMRIG_FEATURE_MO_BENCHMARK -DXMRIG_FEATURE_TLS -DXMRIG_JSON_SINGLE_LINE_ARRAY -DXMRIG_MINER_PROJECT -DXMRIG_OS_LINUX -DXMRIG_OS_UNIX -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D__STDC_FORMAT_MACROS -I/xmrig/src -I/xmrig/src/3rdparty -Wall -Wno-strict-aliasing -maes -O3 -DNDEBUG -Ofast -std=gnu99 -MD -MT CMakeFiles/xmrig.dir/src/crypto/flex/flex_keccak.c.o -MF CMakeFiles/xmrig.dir/src/crypto/flex/flex_keccak.c.o.d -o CMakeFiles/xmrig.dir/src/crypto/flex/flex_keccak.c.o -c /xmrig/src/crypto/flex/flex_keccak.c
/xmrig/src/crypto/flex/flex_keccak.c: In function 'keccak_close28':
/xmrig/src/crypto/flex/flex_keccak.c:1778:7: error: implicit declaration of function 'flex_enc32le_aligned'; did you mean 'sph_enc32le_aligned'? [-Wimplicit-function-declaration]
 1778 |       flex_enc32le_aligned(u.tmp + j, kc->u.narrow[j >> 2]);                    \
      |       ^~~~~~~~~~~~~~~~~~~~

```

env: Alpine Linux x86 (32bit) edge release